### PR TITLE
Add protected user profile routes - Issue #6

### DIFF
--- a/my-app/backend/controllers/userController.js
+++ b/my-app/backend/controllers/userController.js
@@ -1,0 +1,79 @@
+const User = require("../models/User");
+
+// Main change: controller to return the current authenticated user's profile without password fields
+exports.getUserProfile = async (req, res) => {
+  try {
+    const userId = req.user && req.user.id;
+
+    if (!userId) {
+      return res.status(401).json({ message: "Not authorized" });
+    }
+
+    const user = await User.findById(userId).select("-password -passwordHash");
+
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
+
+    return res.status(200).json({
+      id: user._id,
+      username: user.username,
+      name: user.name,
+      email: user.email,
+      college: user.college,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    });
+  } catch (err) {
+    const status = err.statusCode || 500;
+    return res.status(status).json({ message: err.message || "Server error" });
+  }
+};
+
+// Main change: controller to update the current authenticated user's profile in the database
+exports.updateUserProfile = async (req, res) => {
+  try {
+    const userId = req.user && req.user.id;
+
+    if (!userId) {
+      return res.status(401).json({ message: "Not authorized" });
+    }
+
+    const { username, name, email, college } = req.body || {};
+
+    const updates = {};
+
+    if (typeof username === "string") updates.username = username.trim();
+    if (typeof name === "string") updates.name = name.trim();
+    if (typeof email === "string") updates.email = email.trim().toLowerCase();
+    if (typeof college === "string") updates.college = college.trim();
+
+    if (Object.keys(updates).length === 0) {
+      return res.status(400).json({ message: "No valid fields provided for update" });
+    }
+
+    const user = await User.findByIdAndUpdate(userId, updates, {
+      new: true,
+      runValidators: true,
+      context: "query",
+    }).select("-password -passwordHash");
+
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
+
+    return res.status(200).json({
+      id: user._id,
+      username: user.username,
+      name: user.name,
+      email: user.email,
+      college: user.college,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    });
+  } catch (err) {
+    const status = err.statusCode || 500;
+    return res.status(status).json({ message: err.message || "Server error" });
+  }
+};
+

--- a/my-app/backend/middleware/verifyJWT.js
+++ b/my-app/backend/middleware/verifyJWT.js
@@ -1,19 +1,30 @@
 const jwt = require('jsonwebtoken');
+
+// Main change: verify JWT and attach a minimal user object (id) to req.user
 const verifyJWT = (req, res, next) => {
     const authHeader = req.headers.authorization || req.headers.Authorization;
     if (!authHeader?.startsWith('Bearer ')) {
         return res.status(401).json({ message: 'Not authorized, no token provided' });
     }
+
     const token = authHeader.split(' ')[1];
+
     jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
         if (err) {
             return res.status(403).json({ message: 'Forbidden, invalid token' });
         }
-        req.user = decoded.user;
-        //req.user = decoded;
-        req.roles = decoded.roles;
+
+        // Support tokens that store the user id either directly or under decoded.user.id
+        const userId = decoded?.user?.id || decoded?.id;
+        if (!userId) {
+            return res.status(401).json({ message: 'Not authorized, invalid token payload' });
+        }
+
+        req.user = { id: userId };
+        req.roles = decoded.roles || [];
+
         next();
     });
 };
-    
+
 module.exports = verifyJWT;

--- a/my-app/backend/package.json
+++ b/my-app/backend/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "nodemon server.js"
   },

--- a/my-app/backend/routes/userRoutes.js
+++ b/my-app/backend/routes/userRoutes.js
@@ -1,0 +1,18 @@
+const express = require("express");
+
+const verifyJWT = require("../middleware/verifyJWT");
+const {
+  getUserProfile,
+  updateUserProfile,
+} = require("../controllers/userController");
+
+const router = express.Router();
+
+// Main change: route to get the authenticated user's profile (protected)
+router.get("/me", verifyJWT, getUserProfile);
+
+// Main change: route to update the authenticated user's profile (protected)
+router.patch("/me", verifyJWT, updateUserProfile);
+
+module.exports = router;
+

--- a/my-app/backend/server.js
+++ b/my-app/backend/server.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 require('dotenv').config({ path: '.env' });
 
 const authRoutes = require("./routes/authRoutes");
+const userRoutes = require("./routes/userRoutes");
 
 const app = express();
 
@@ -14,7 +15,11 @@ mongoose.connect(process.env.MONGO_URI)
   .then(() => console.log('MongoDB connected'))
   .catch(err => console.log(err));
 
+// Main change: mount authentication routes
 app.use("/api/auth", authRoutes);
+
+// Main change: mount user profile management routes
+app.use("/api/users", userRoutes);
 
 app.get('/', (req, res) => {
   res.send('API is running');


### PR DESCRIPTION
## Summary
- Add JWT-protected user profile controllers for getting and updating the current user
- Wire new user routes under `/api/users` using the existing `verifyJWT` middleware
- Update `verifyJWT` to read the user id from the current auth token payload
- Add an `npm start` script for the backend server

## Changes
- New `userController.js` with:
  - `getUserProfile`: returns the authenticated user's profile without password fields
  - `updateUserProfile`: updates username/name/email/college for the authenticated user and returns the updated profile (no password fields)
- New `userRoutes.js` exposing:
  - `GET /api/users/me` (protected, returns current user profile)
  - `PATCH /api/users/me` (protected, updates current user profile)
- Updated `verifyJWT.js`:
  - Supports tokens that store the user id as either `decoded.id` or `decoded.user.id`
  - Attaches `req.user = { id }` and keeps `req.roles` if present
- Updated `server.js`:
  - Mounts `/api/users` routes alongside existing `/api/auth`
- Updated `backend/package.json`:
  - Adds `"start": "node server.js"` so the backend can run with `npm start`

## Security / Secrets
- All secrets (e.g. `MONGO_URI`, `JWT_SECRET`) are loaded from `.env` files that are git-ignored.
- No MongoDB URLs or API keys are committed in this branch.

## Testing
- From `my-app/backend`:
  - `npm start` (requires valid `MONGO_URI` and `JWT_SECRET` in `.env`)
- With a valid JWT from `/api/auth/login`:
  - `GET /api/users/me` with `Authorization: Bearer <token>` returns the current user profile without password fields.
  - `PATCH /api/users/me` with `Authorization: Bearer <token>` and a JSON body (e.g. `{ "name": "New Name" }`) updates the profile and returns the updated user (no password fields).